### PR TITLE
Reducing zabbix sudo access to python scripts only and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Zabbix template for letsencrypt certificates monitoring.
 
 Don't forget change paths:
 
-1. Edit `/etc/sudoers` and add this line: ```zabbix  ALL=(ALL:ALL) NOPASSWD:ALL```
+1. Copy sudo permissions ```cp -r ./zabbix_letsencrypt/conf/zabbix_letsencrypt /etc/sudoers.d/```
 
 2. Copy scripts: ```cp -r ./zabbix_letsencrypt/scripts/letsencrypt /etc/zabbix/scripts/```
 

--- a/conf/zabbix_letsencrypt
+++ b/conf/zabbix_letsencrypt
@@ -1,0 +1,3 @@
+Cmnd_Alias ZABB = /etc/zabbix/scripts/letsencrypt/cert_discovery.py, /etc/zabbix/scripts/letsencrypt/cert_check.py
+Defaults:zabbix !requiretty
+zabbix ALL=NOPASSWD: ZABB


### PR DESCRIPTION
First of all, thank you for writing an easy way to monitor the certificates done by Let's Encrypt!

I would like to help by reducing zabbix user sudo access, as it does not need unrestricted access to everything, it's enough to allow him access to your python scripts.

I've created a file in the conf/ folder which has the required access lines and also a proper name in case the user using this project has an existing file in /etc/sudoers.d/ named zabbix, so I've named it zabbix_letsencrypt.

If that way is not suitable, then the user can easily copy paste this code line (can be added easily to the README.md file):

```
cat <<EOT > /etc/sudoers.d/zabbix_letsencrypt
Cmnd_Alias ZABB = /etc/zabbix/scripts/letsencrypt/cert_discovery.py, /etc/zabbix/scripts/letsencrypt/cert_check.py
Defaults:zabbix !requiretty
zabbix ALL=NOPASSWD: ZABB
EOT
```
Thanks!